### PR TITLE
Update gatsby-config.js with new API calls

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,7 +18,7 @@ module.exports = {
         token: process.env.GATSBY_GRAPHQLCMS_TOKEN,
         // Get all remote data
         query: `{
-          allPosts {
+          posts {
             id
             slug
             title
@@ -28,7 +28,7 @@ module.exports = {
               handle
             }
           }
-          allAuthors {
+          authors {
             id
             name
             bibliography


### PR DESCRIPTION
Replaced allPosts and allAuthors with the appropiate values for the newer GraphCMS API.

GraphCMS docs comparing new vs old API: https://docs.graphcms.com/developers/api/api-old-and-new